### PR TITLE
Configure Vite base path for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/portuguese-phrase-reorder-game/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Portuguese Phrase Reorder Game</title>
   </head>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview --base /portuguese-phrase-reorder-game/"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/public/vite.svg
+++ b/public/vite.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title">
+  <title id="title">Portuguese Phrase Reorder Game icon</title>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#0ea5e9" />
+      <stop offset="100%" stop-color="#6366f1" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="12" fill="url(#bg)" />
+  <path d="M18 46 L32 18 L46 46 Z" fill="#facc15" />
+</svg>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const GH_PAGES_BASE_PATH = '/portuguese-phrase-reorder-game/'
+
 export default defineConfig({
   plugins: [react()],
+  base: GH_PAGES_BASE_PATH,
 })


### PR DESCRIPTION
## Summary
- set the Vite build base to `/portuguese-phrase-reorder-game/` so static assets resolve correctly on GitHub Pages
- update the preview npm script and favicon reference to respect the deployment subdirectory
- add a matching SVG icon in the public folder for the favicon reference

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf31b8ca88832494b75e019578cc0c