### PR TITLE
Persist session state and add service worker registration

### DIFF
--- a/src/data/problems.ts
+++ b/src/data/problems.ts
@@ -55,3 +55,21 @@ export async function fetchProblems(options: FetchProblemsOptions = {}): Promise
 export function getProblemsUrl(): string {
   return PROBLEMS_URL
 }
+
+function hashText(value: string): number {
+  let hash = 0x811c9dc5
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193)
+  }
+
+  return hash >>> 0
+}
+
+export function createProblemSetHash(problems: ProblemSet): string {
+  const serialized = JSON.stringify(problems)
+  const digest = hashText(serialized).toString(16).padStart(8, '0')
+  const lengthComponent = serialized.length.toString(16).padStart(6, '0')
+
+  return `problems-${lengthComponent}-${digest}`
+}

--- a/src/hooks/usePersistentState.ts
+++ b/src/hooks/usePersistentState.ts
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react'
+
+interface PersistentStateOptions<T> {
+  storage?: Storage
+  serialize?: (value: T) => string
+  deserialize?: (value: string) => T
+}
+
+function defaultSerialize<T>(value: T): string {
+  return JSON.stringify(value)
+}
+
+function defaultDeserialize<T>(value: string): T {
+  return JSON.parse(value) as T
+}
+
+export function usePersistentState<T>(
+  key: string | null,
+  initializer: () => T,
+  options: PersistentStateOptions<T> = {},
+): [T, Dispatch<SetStateAction<T>>] {
+  const storage = options.storage ?? (typeof window !== 'undefined' ? window.localStorage : null)
+  const serialize = options.serialize ?? defaultSerialize<T>
+  const deserialize = options.deserialize ?? defaultDeserialize<T>
+
+  const initializerRef = useRef(initializer)
+  initializerRef.current = initializer
+
+  const deserializeRef = useRef(deserialize)
+  deserializeRef.current = deserialize
+
+  const readStoredValue = useCallback(
+    (targetKey: string | null): T => {
+      const currentInitializer = initializerRef.current
+      const currentDeserialize = deserializeRef.current
+
+      if (!storage || targetKey === null) {
+        return currentInitializer()
+      }
+
+      try {
+        const rawValue = storage.getItem(targetKey)
+        if (rawValue === null) {
+          return currentInitializer()
+        }
+
+        return currentDeserialize(rawValue)
+      } catch (error) {
+        console.warn(`Failed to read persistent state for key "${targetKey}".`, error)
+        return currentInitializer()
+      }
+    },
+    [storage],
+  )
+
+  const [state, setState] = useState<T>(() => readStoredValue(key))
+  const previousKeyRef = useRef<string | null>(key)
+
+  useEffect(() => {
+    if (previousKeyRef.current === key) {
+      return
+    }
+
+    setState(readStoredValue(key))
+    previousKeyRef.current = key
+  }, [key, readStoredValue])
+
+  useEffect(() => {
+    if (!storage || key === null) {
+      return
+    }
+
+    try {
+      const serialized = serialize(state)
+      storage.setItem(key, serialized)
+    } catch (error) {
+      console.warn(`Failed to persist state for key "${key}".`, error)
+    }
+  }, [key, serialize, state, storage])
+
+  return [state, setState]
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,3 +8,18 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <App />
   </React.StrictMode>,
 )
+
+if ('serviceWorker' in navigator && import.meta.env.PROD) {
+  const registerServiceWorker = () => {
+    const serviceWorkerUrl = `${import.meta.env.BASE_URL}service-worker.js`
+    navigator.serviceWorker.register(serviceWorkerUrl).catch((error) => {
+      console.error('Service worker registration failed:', error)
+    })
+  }
+
+  if (document.readyState === 'complete') {
+    registerServiceWorker()
+  } else {
+    window.addEventListener('load', registerServiceWorker, { once: true })
+  }
+}


### PR DESCRIPTION
## Summary
- persist the active session in local storage using a problem set hash so progress restores across reloads and resets when data changes
- add a reusable persistent state hook and hashing utility to support the new storage behavior
- register the service worker during production builds to enable installable/offline support

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfbd173dc4832485bc5388ed8d7e6a