### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./dist
+          force_orphan: true


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the app on pushes to `main` and on manual dispatch
- install dependencies, run the existing build, and publish the `dist/` output to the `gh-pages` branch via `peaceiris/actions-gh-pages`
- noted that SPEC.md currently ends at task 9, so only the deployment automation could be implemented

## Testing
- npx yaml-lint .github/workflows/deploy.yml
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfc28830e483249f5494f7382cde9d