### PR TITLE
Improve drag behaviour to avoid reflow

### DIFF
--- a/src/components/Token.module.css
+++ b/src/components/Token.module.css
@@ -37,41 +37,47 @@
   box-shadow: 0 18px 44px -24px rgba(37, 99, 235, 0.65);
 }
 
+.token[data-dragging='true']:not([data-overlay='true']) {
+  opacity: 0.35;
+}
+
 .token[data-locked='true'][data-dragging='true'] {
   box-shadow: 0 16px 32px -24px rgba(22, 163, 74, 0.45);
 }
 
-.token::before,
-.token::after {
-  content: '';
+.token[data-locked='true'][data-dragging='true']:not([data-overlay='true']) {
+  opacity: 0.5;
+}
+
+.indicator {
   position: absolute;
   top: 14%;
   bottom: 14%;
   width: 4px;
   border-radius: 999px;
   background: var(--color-primary);
+  visibility: hidden;
   opacity: 0;
   transform: scaleY(0.7);
   transition: opacity 120ms ease, transform 120ms ease;
   pointer-events: none;
 }
 
-.token::before {
+.indicator[data-side='left'] {
   left: -0.4rem;
 }
 
-.token::after {
+.indicator[data-side='right'] {
   right: -0.4rem;
 }
 
-.token[data-drop-indicator='before']::before,
-.token[data-drop-indicator='after']::after {
+.indicator[data-visible='true'] {
+  visibility: visible;
   opacity: 1;
   transform: scaleY(1);
 }
 
-.token[data-locked='true']::before,
-.token[data-locked='true']::after {
+.token[data-locked='true'] .indicator {
   background: var(--color-success-strong);
 }
 

--- a/src/components/Token.tsx
+++ b/src/components/Token.tsx
@@ -20,8 +20,8 @@ function Token({ fragment, text, dropIndicator }: TokenProps) {
   const { tabIndex, ...restAttributes } = sortableAttributes
 
   const style: CSSProperties = {
-    transform: transform ? CSS.Transform.toString(transform) : undefined,
-    transition,
+    transform: !isDragging && transform ? CSS.Transform.toString(transform) : undefined,
+    transition: isDragging ? undefined : transition,
   }
 
   const resolvedTabIndex = fragment.locked ? -1 : tabIndex ?? 0
@@ -33,13 +33,24 @@ function Token({ fragment, text, dropIndicator }: TokenProps) {
       style={style}
       data-locked={fragment.locked ? 'true' : undefined}
       data-dragging={isDragging ? 'true' : undefined}
-      data-drop-indicator={dropIndicator ?? undefined}
       tabIndex={resolvedTabIndex}
       aria-disabled={fragment.locked || undefined}
       {...restAttributes}
       {...(fragment.locked ? undefined : listeners)}
     >
+      <span
+        className={styles.indicator}
+        data-side="left"
+        data-visible={dropIndicator === 'before' ? 'true' : undefined}
+        aria-hidden="true"
+      />
       <span className={styles.text}>{text}</span>
+      <span
+        className={styles.indicator}
+        data-side="right"
+        data-visible={dropIndicator === 'after' ? 'true' : undefined}
+        aria-hidden="true"
+      />
     </li>
   )
 }


### PR DESCRIPTION
## Summary
- keep sortable tokens in place while dragging and fade the active token instead of removing it
- render persistent left/right drop indicators that toggle visibility without causing layout shifts
- compute drop position based on pointer proximity and reinsert the fragment only after drop

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d017b837dc83249af015fb29c35087